### PR TITLE
Add OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+Create a `.env.local` file with the following variables:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+```
+
+`NEXT_PUBLIC_SITE_URL` must also be listed in the **Redirect URLs** section of your Supabase project settings so that OAuth sign in can complete successfully.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,6 +7,18 @@ export default function LoginPage() {
   const [message, setMessage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const signInWithGoogle = async () => {
+    await supabase.auth.signInWithOAuth({ provider: "google" });
+  };
+
+  const signInWithVk = async () => {
+    await supabase.auth.signInWithOAuth({ provider: "vk" });
+  };
+
+  const signInWithGithub = async () => {
+    await supabase.auth.signInWithOAuth({ provider: "github" });
+  };
+
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -52,6 +64,26 @@ export default function LoginPage() {
           {loading ? "Отправка..." : "Получить ссылку для входа"}
         </button>
       </form>
+      <div className="mt-6 space-y-2">
+        <button
+          onClick={signInWithGoogle}
+          className="w-full bg-red-600 text-white p-2 rounded hover:bg-red-700 transition"
+        >
+          Войти через Google
+        </button>
+        <button
+          onClick={signInWithVk}
+          className="w-full bg-green-600 text-white p-2 rounded hover:bg-green-700 transition"
+        >
+          Войти через VK
+        </button>
+        <button
+          onClick={signInWithGithub}
+          className="w-full bg-gray-800 text-white p-2 rounded hover:bg-gray-900 transition"
+        >
+          Войти через GitHub
+        </button>
+      </div>
       {message && <p className="mt-4 text-center">{message}</p>}
     </main>
   );


### PR DESCRIPTION
## Summary
- implement Google, VK and GitHub sign-in handlers
- add OAuth buttons to the login page
- document Supabase environment variables and redirect URL requirement

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68537d7c603c832d995aaaee59d20a99