### PR TITLE
Fix dynamic route params handling

### DIFF
--- a/src/app/[subject]/page.tsx
+++ b/src/app/[subject]/page.tsx
@@ -11,12 +11,12 @@ import Link from "next/link";
  */
 
 type Props = {
-  params: { subject: string }; // No longer a Promise, Next.js handles this for async components
+  params: { subject: string }; // Next.js passes params synchronously
 };
 
-export default async function SubjectPage(props: Props) {
+export default async function SubjectPage({ params }: Props) {
   /* ---------- slug из маршрута ---------- */
-  const { subject } = await props.params;
+  const { subject } = params;
 
   /* ---------- предмет из БД ---------- */
   const { data: subjRow, error: subjErr } = await supabase

--- a/src/app/[subject]/task/[task]/page.tsx
+++ b/src/app/[subject]/task/[task]/page.tsx
@@ -5,12 +5,12 @@ import { subjectsMeta } from "../../../config/subjectsMeta";
 import TaskCard from "../../../components/TaskCard";
 
 type Props = {
-  params: { subject: string; task: string }; // No longer a Promise
+  params: { subject: string; task: string }; // params are synchronous
 };
 
-export default async function TaskPage(props: Props) {
+export default async function TaskPage({ params }: Props) {
   /* ---------- Маршрут ---------- */
-  const { subject, task } = await props.params; // task — uuid-строка
+  const { subject, task } = params; // task — uuid-строка
 
   /* ---------- Предмет ---------- */
   const { data: subj, error: subjErr } = await supabase

--- a/src/app/[subject]/type/[type]/page.tsx
+++ b/src/app/[subject]/type/[type]/page.tsx
@@ -6,14 +6,14 @@ import { subjectsMeta } from "../../../config/subjectsMeta";
 import TaskCard from "../../../components/TaskCard";
 
 type Props = {
-  params: { subject: string; type: string }; // No longer a Promise
+  params: { subject: string; type: string }; // params are synchronous
 };
 
-export default async function TypeTasksPage(props: Props) {
+export default async function TypeTasksPage({ params }: Props) {
   // --- параметры маршрута ---
 
 
-  const { subject, type } = await props.params;
+  const { subject, type } = params;
   const typeNum = Number(type);
 
   if (Number.isNaN(typeNum) || typeNum <= 0) {

--- a/src/app/[subject]/variant/[variant]/page.tsx
+++ b/src/app/[subject]/variant/[variant]/page.tsx
@@ -6,12 +6,12 @@ import { Suspense } from "react";
 
 
 type Props = {
-  params: { subject: string; variant: string }; // No longer a Promise
+  params: { subject: string; variant: string }; // params are synchronous
 };
 
-export default async function VariantPage(props: Props) {
+export default async function VariantPage({ params }: Props) {
   /* ---------- параметры маршрута ---------- */
-  const { subject, variant } = await props.params;
+  const { subject, variant } = params;
 
   /* ---------- предмет ---------- */
   const { data: subj, error: subjErr } = await supabase


### PR DESCRIPTION
## Summary
- remove outdated `await` calls for route params on subject pages
- update param comments

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68739b50b7e8832d97e373991a79d675