### PR TITLE
Enable dark theme by default

### DIFF
--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -3,12 +3,12 @@
 import { useEffect, useState } from "react";
 
 export default function ThemeToggle() {
-  const [dark, setDark] = useState(false);
+  const [dark, setDark] = useState(true);
 
   useEffect(() => {
     const saved = localStorage.getItem("theme");
     if (saved) setDark(saved === "dark");
-    else setDark(window.matchMedia("(prefers-color-scheme: dark)").matches);
+    else setDark(true);
   }, []);
 
   useEffect(() => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       )}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
         >


### PR DESCRIPTION
## Summary
- set dark theme as default in ThemeProvider
- default to dark theme if no preference is stored

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6873aa0843c8832da49e91cec7594977