### PR TITLE
style(subject): use shadcn button variant

### DIFF
--- a/src/app/[subject]/page.tsx
+++ b/src/app/[subject]/page.tsx
@@ -98,11 +98,7 @@ const typeNums = Array.from(
         ) : (
           <div className="flex flex-wrap gap-2">
             {typeNums.map(n => (
-              <Button
-                asChild
-                key={n}
-                className="px-3 py-1 border rounded bg-gray-800 hover:bg-gray-700"
-              >
+              <Button asChild key={n} variant="outline" size="sm">
                 <Link href={`/${subject}/type/${n}`}>Тип {n}</Link>
               </Button>
             ))}


### PR DESCRIPTION
## Summary
- apply standard `Button` variant in the "Типы заданий" section

## Testing
- `npm run build` *(fails: Supabase project URL and API key required)*

------
https://chatgpt.com/codex/tasks/task_e_687655e595f4832d953cce0d2b80453f