### PR TITLE
Theme-aware task card

### DIFF
--- a/src/app/components/TaskCard/index.tsx
+++ b/src/app/components/TaskCard/index.tsx
@@ -39,7 +39,7 @@ export default function TaskCard(props: TaskCardProps) {
     };
 
     return (
-      <div className="border rounded-lg bg-gray-800 p-4 mb-4">
+      <div className="border rounded-lg bg-card text-card-foreground p-4 mb-4">
         <TaskHead task={task} subject={subject} />
         <TaskStatement html={task.body_md} />
         <TaskInput
@@ -67,7 +67,7 @@ export default function TaskCard(props: TaskCardProps) {
 
   return (
     <div
-      className={`border rounded-lg bg-gray-800 p-4 mb-4 ${
+      className={`border rounded-lg bg-card text-card-foreground p-4 mb-4 ${
         disabled ? "opacity-60 pointer-events-none" : ""
       }`}
     >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,9 @@
   --secondary: 210 40% 96.1%;
   --secondary-foreground: 222.2 47.4% 11.2%;
 
+  --card: var(--secondary);
+  --card-foreground: var(--secondary-foreground);
+
   /* … остальные */
 }
 
@@ -26,6 +29,9 @@
 
   --secondary: 222.2 47.4% 11.2%;
   --secondary-foreground: 210 40% 98%;
+
+  --card: var(--secondary);
+  --card-foreground: var(--secondary-foreground);
 
   /* … */
 }


### PR DESCRIPTION
## Summary
- define CSS variables for card background and foreground
- use card theme variables for task card so it reacts to theme changes

## Testing
- `npm install`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68766519cc68832d8230f7f1da26b2cf