### PR TITLE
Standardize TaskCard UI

### DIFF
--- a/src/app/components/TaskCard/TaskInput.tsx
+++ b/src/app/components/TaskCard/TaskInput.tsx
@@ -1,5 +1,6 @@
 // src/app/components/TaskCard/TaskInput.tsx
 import type { UserAnswer } from "./utils/helpers";
+import { Input } from "@/components/ui/input";
 
 /** Свитчер всех форм ввода по answerType. */
 export default function TaskInput({
@@ -19,9 +20,9 @@ export default function TaskInput({
       return (
         <div className="flex gap-2">
           {[0, 1].map(idx => (
-            <input
+            <Input
               key={idx}
-              className="border rounded px-2 py-1"
+              className="flex-1"
               value={(answer as string[])[idx] ?? ""}
               onChange={e => {
                 const next = [...(answer as string[])];
@@ -44,8 +45,8 @@ export default function TaskInput({
               <tr key={r}>
                 {[0, 1].map(c => (
                   <td key={c} className="p-1">
-                    <input
-                      className="border rounded px-2 py-1 w-16"
+                    <Input
+                      className="w-16"
                       value={(answer as string[][])[r]?.[c] ?? ""}
                       onChange={e => {
                         const next = (answer as string[][]).map(row => [
@@ -67,8 +68,8 @@ export default function TaskInput({
 
     default:
       return (
-        <input
-          className="border rounded px-2 py-1 w-full"
+        <Input
+          className="w-full"
           value={(answer as string) ?? ""}
           onChange={e => onChange(e.target.value)}
           placeholder="Ваш ответ"

--- a/src/app/components/TaskCard/index.tsx
+++ b/src/app/components/TaskCard/index.tsx
@@ -2,6 +2,7 @@
 
 "use client";
 import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
 import type {
   Task,
   UserAnswer,
@@ -39,26 +40,28 @@ export default function TaskCard(props: TaskCardProps) {
     };
 
     return (
-      <div className="border rounded-lg bg-card text-card-foreground p-4 mb-4">
-        <TaskHead task={task} subject={subject} />
-        <TaskStatement html={task.body_md} />
-        <TaskInput
-          answerType={answerType}
-          answer={userAnswer}
-          onChange={setUserAnswer}
-        />
-        <SingleControls
-          onCheck={handleCheck}
-          score={score}
-          maxScore={maxScore}
-        />
-        <SolutionBlock
-          open={showSolution}
-          onToggle={() => setShowSolution(s => !s)}
-          answer={task.answer_json}
-          solution={task.solution_md}
-        />
-      </div>
+      <Card className="mb-4">
+        <CardContent className="space-y-4">
+          <TaskHead task={task} subject={subject} />
+          <TaskStatement html={task.body_md} />
+          <TaskInput
+            answerType={answerType}
+            answer={userAnswer}
+            onChange={setUserAnswer}
+          />
+          <SingleControls
+            onCheck={handleCheck}
+            score={score}
+            maxScore={maxScore}
+          />
+          <SolutionBlock
+            open={showSolution}
+            onToggle={() => setShowSolution(s => !s)}
+            answer={task.answer_json}
+            solution={task.solution_md}
+          />
+        </CardContent>
+      </Card>
     );
   }
 
@@ -66,19 +69,19 @@ export default function TaskCard(props: TaskCardProps) {
   const { value, onChange, disabled } = props as VariantModeProps;
 
   return (
-    <div
-      className={`border rounded-lg bg-card text-card-foreground p-4 mb-4 ${
-        disabled ? "opacity-60 pointer-events-none" : ""
-      }`}
+    <Card
+      className={`mb-4 ${disabled ? "opacity-60 pointer-events-none" : ""}`}
     >
-      <TaskHead task={task} subject={subject} />
-      <TaskStatement html={task.body_md} />
-      <TaskInput
-        answerType={answerType}
-        answer={value}
-        onChange={onChange}
-        disabled={disabled}
-      />
-    </div>
+      <CardContent className="space-y-4">
+        <TaskHead task={task} subject={subject} />
+        <TaskStatement html={task.body_md} />
+        <TaskInput
+          answerType={answerType}
+          answer={value}
+          onChange={onChange}
+          disabled={disabled}
+        />
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- refactor TaskCard to use shared Card component
- replace plain inputs with `<Input>`

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Supabase credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_687686fdf9a4832dbee5f6c51ea67b27