### PR TITLE
Create shared answer formatter

### DIFF
--- a/src/app/components/TaskCard/utils/helpers.tsx
+++ b/src/app/components/TaskCard/utils/helpers.tsx
@@ -1,6 +1,7 @@
 // src/app/components/TaskCard/utils/helpers.tsx
 
 import React from "react";
+import { formatAnswer } from "@/utils/formatAnswer";
 
 /* ---------- Типы данных ---------- */
 export type UserAnswer = string | string[] | string[][];
@@ -58,28 +59,4 @@ export function getInitialAnswer(answerType: string = "single"): UserAnswer {
 }
 
 /* ---------- formatAnswer (для SolutionBlock) ---------- */
-export function formatAnswer(ans: any): string | React.ReactElement {
-  if (Array.isArray(ans)) {
-    // двумерный массив → таблица
-    if (ans.length > 0 && Array.isArray(ans[0])) {
-      return (
-        <table className="border border-gray-500 rounded my-2">
-          <tbody>
-            {ans.map((row: any[], i: number) => (
-              <tr key={i}>
-                {row.map((cell: any, j: number) => (
-                  <td key={j} className="px-2 py-1 border border-gray-400">
-                    {cell}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      );
-    }
-    // одномерный массив
-    return ans.join(", ");
-  }
-  return String(ans);
-}
+export { formatAnswer };

--- a/src/app/components/TaskResultView.tsx
+++ b/src/app/components/TaskResultView.tsx
@@ -3,6 +3,7 @@
 "use client";
 
 import { useState } from "react";
+import { formatAnswer } from "@/utils/formatAnswer";
 
 // Типы для props (расширяй под свои нужды)
 type TaskResultViewProps = {
@@ -16,31 +17,6 @@ type TaskResultViewProps = {
   };
 };
 
-// Форматирование ответа (массивы, таблицы и строки)
-function formatAnswer(answer: any) {
-  if (Array.isArray(answer)) {
-    if (Array.isArray(answer[0])) {
-      return (
-        <table className="border border-gray-500 rounded my-2">
-          <tbody>
-            {answer.map((row: any[], i: number) => (
-              <tr key={i}>
-                {row.map((cell: any, j: number) => (
-                  <td key={j} className="px-2 py-1 border border-gray-400">
-                    {cell}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      );
-    } else {
-      return answer.join(", ");
-    }
-  }
-  return String(answer);
-}
 
 // Основной компонент
 export default function TaskResultView({ task, userAnswer, result }: TaskResultViewProps) {

--- a/src/utils/formatAnswer.tsx
+++ b/src/utils/formatAnswer.tsx
@@ -1,0 +1,32 @@
+// src/utils/formatAnswer.tsx
+import React from "react";
+
+/**
+ * Formats an answer for display. Supports strings, one-dimensional arrays and
+ * two-dimensional arrays (rendered as a table).
+ */
+export function formatAnswer(ans: any): string | React.ReactElement {
+  if (Array.isArray(ans)) {
+    // two-dimensional array → table
+    if (ans.length > 0 && Array.isArray(ans[0])) {
+      return (
+        <table className="border border-gray-500 rounded my-2">
+          <tbody>
+            {ans.map((row: any[], i: number) => (
+              <tr key={i}>
+                {row.map((cell: any, j: number) => (
+                  <td key={j} className="px-2 py-1 border border-gray-400">
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+    // one-dimensional array
+    return ans.join(", ");
+  }
+  return String(ans);
+}


### PR DESCRIPTION
## Summary
- centralize answer formatting logic
- remove duplicate implementations

## Testing
- `npm run lint` *(fails: configuration not set up)*

------
https://chatgpt.com/codex/tasks/task_e_6877cdb61190832d8993c418bafc5763