### PR TITLE
Use alias imports in subject pages

### DIFF
--- a/src/app/[subject]/page.tsx
+++ b/src/app/[subject]/page.tsx
@@ -1,6 +1,6 @@
 // src/app/[subject]/page.tsx
 
-import { subjectsMeta } from "../config/subjectsMeta";
+import { subjectsMeta } from "@/app/config/subjectsMeta";
 import { createClient } from "@/utils/supabase/server";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";

--- a/src/app/[subject]/task/[task]/page.tsx
+++ b/src/app/[subject]/task/[task]/page.tsx
@@ -1,8 +1,8 @@
 // src/app/[subject]/task/[task]/page.tsx
 
 import { createClient } from "@/utils/supabase/server";
-import { subjectsMeta } from "../../../config/subjectsMeta";
-import TaskCard from "../../../components/TaskCard";
+import { subjectsMeta } from "@/app/config/subjectsMeta";
+import TaskCard from "@/app/components/TaskCard";
 
 type Props = {
   params: Promise<{ subject: string; task: string }>;

--- a/src/app/[subject]/type/[type]/page.tsx
+++ b/src/app/[subject]/type/[type]/page.tsx
@@ -2,8 +2,8 @@
 
 
 import { createClient } from "@/utils/supabase/server";
-import { subjectsMeta } from "../../../config/subjectsMeta";
-import TaskCard from "../../../components/TaskCard";
+import { subjectsMeta } from "@/app/config/subjectsMeta";
+import TaskCard from "@/app/components/TaskCard";
 
 type Props = {
   params: Promise<{ subject: string; type: string }>;

--- a/src/app/[subject]/variant/[variant]/page.tsx
+++ b/src/app/[subject]/variant/[variant]/page.tsx
@@ -1,7 +1,7 @@
 // src/app/[subject]/variant/[variant]/page.tsx
 
 import { createClient } from "@/utils/supabase/server";
-import { subjectsMeta } from "../../../config/subjectsMeta";
+import { subjectsMeta } from "@/app/config/subjectsMeta";
 import { Suspense } from "react";
 
 

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -4,7 +4,7 @@
 import Link from "next/link";
 import ThemeToggle from "./ThemeToggle";
 import { AuthNav } from "./AuthNav";
-import { subjectsMeta } from "../config/subjectsMeta";
+import { subjectsMeta } from "@/app/config/subjectsMeta";
 import {
   Select,
   SelectContent,


### PR DESCRIPTION
## Summary
- simplify imports in subject pages by using path alias `@`
- update Header to use the same alias

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6877cdb87d90832d89f6b525061ff337