### PR TITLE
Switch to mdx fields in tasks

### DIFF
--- a/src/app/components/TaskCard/index.tsx
+++ b/src/app/components/TaskCard/index.tsx
@@ -43,7 +43,7 @@ export default function TaskCard(props: TaskCardProps) {
       <Card className="mb-4">
         <CardContent className="space-y-4">
           <TaskHead task={task} subject={subject} />
-          <TaskStatement html={task.body_md} />
+          <TaskStatement html={task.body_mdx} />
           <TaskInput
             answerType={answerType}
             answer={userAnswer}
@@ -58,7 +58,7 @@ export default function TaskCard(props: TaskCardProps) {
             open={showSolution}
             onToggle={() => setShowSolution(s => !s)}
             answer={task.answer_json}
-            solution={task.solution_md}
+            solution={task.solution_mdx}
           />
         </CardContent>
       </Card>
@@ -74,7 +74,7 @@ export default function TaskCard(props: TaskCardProps) {
     >
       <CardContent className="space-y-4">
         <TaskHead task={task} subject={subject} />
-        <TaskStatement html={task.body_md} />
+        <TaskStatement html={task.body_mdx} />
         <TaskInput
           answerType={answerType}
           answer={value}

--- a/src/app/components/TaskCard/utils/helpers.tsx
+++ b/src/app/components/TaskCard/utils/helpers.tsx
@@ -8,9 +8,9 @@ export type UserAnswer = string | string[] | string[][];
 
 export type Task = {
   id: string;
-  body_md: string;
+  body_mdx: string;
   answer_json: any;
-  solution_md: string | null;
+  solution_mdx: string | null;
   type_num: number | null;
   answer_type?: string;
   maxScore?: number;
@@ -18,6 +18,9 @@ export type Task = {
   task_num_text?: string | null;
   notes_text?: string | null;
   source?: string | null;
+  tables_data?: any;
+  svg_data?: any;
+  img_urls?: string[] | null;
   // ... если будут ещё новые поля — добавь их сюда
 };
 


### PR DESCRIPTION
## Summary
- replace task body/solution fields with `body_mdx` and `solution_mdx`
- include additional task metadata (`tables_data`, `svg_data`, `img_urls`)
- update `TaskCard` component to use the new field names

## Testing
- `npm run lint` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687937c41674832db3cec0cf5fe5a16f