### PR TITLE
Specify columns in Supabase queries

### DIFF
--- a/src/app/[subject]/task/[task]/page.tsx
+++ b/src/app/[subject]/task/[task]/page.tsx
@@ -32,7 +32,11 @@ export default async function TaskPage(props: Props) {
   /* ---------- Задача ---------- */
   const { data: taskRow, error: taskErr } = await supabase
     .from("tasks_static")
-    .select("*")
+    .select(
+      `id, type_num, body_mdx, solution_mdx, tables_data, svg_data, img_urls,
+       answer_json, answer_type, maxScore, task_num_text, notes_text, source,
+       difficulty`
+    )
     .eq("subject_id", subj.id)
     .eq("id", task)            // id — primary key UUID
     .single();

--- a/src/app/[subject]/type/[type]/page.tsx
+++ b/src/app/[subject]/type/[type]/page.tsx
@@ -44,7 +44,11 @@ export default async function TypeTasksPage(props: Props) {
   // --- задачи этого типа ---
   const { data: tasks, error: taskErr } = await supabase
     .from("tasks_static")
-    .select("*")
+    .select(
+      `id, type_num, body_mdx, solution_mdx, tables_data, svg_data, img_urls,
+       answer_json, answer_type, maxScore, task_num_text, notes_text, source,
+       difficulty`
+    )
     .eq("subject_id", subjRow.id)
     .eq("type_num", typeNum)
     .order("difficulty", { ascending: true });


### PR DESCRIPTION
## Summary
- avoid `select("*")` on `tasks_static`
- explicitly request new columns like `body_mdx` and `solution_mdx`

## Testing
- `npm run lint` *(fails: requires initial configuration)*
- `npm run build` *(fails: Supabase credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_687937c660b4832d89c21afaa7ca14bd