### PR TITLE
Remove async cookie call in server supabase helper

### DIFF
--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,9 +1,9 @@
 // src/utils/supabase/server.ts
-import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
-export async function createClient() {
-  const store = await cookies();
+export function createClient() {
+  const store = cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,


### PR DESCRIPTION
## Summary
- switch supabase server helper to synchronous `cookies()` call
- drop unused `CookieOptions` import

## Testing
- `npx eslint src/utils/supabase/server.ts`
- `npm run lint` *(fails: comments inside JSX, invalid hooks, etc.)*
- `npm run build` *(fails: module not found '@mdx-js/mdx')*

------
https://chatgpt.com/codex/tasks/task_e_687a72d9dfd4832da72a9ec6a9f9b678