### PR TITLE
Fix PageProps and Variant checker types

### DIFF
--- a/src/app/[subject]/task/[task]/page.tsx
+++ b/src/app/[subject]/task/[task]/page.tsx
@@ -4,12 +4,12 @@ import { createClient } from "@/utils/supabase/server";
 import TaskCard from "@/app/components/TaskCard";
 
 type PageProps = {
-  params: { subject: string; task: string };
+  params: Promise<{ subject: string; task: string }>;
 };
 
 export default async function Page({ params }: PageProps) {
   const supabase = await createClient();
-  const { subject, task } = params;
+  const { subject, task } = await params;
 
   // 1. Найти id предмета
   const { data: subjRow, error: subjErr } = await supabase

--- a/src/utils/checkVariant.ts
+++ b/src/utils/checkVariant.ts
@@ -1,11 +1,11 @@
 // src/utils/checkVariant.ts
 
-import { checkAnswer, CheckResult } from "./checkAnswer";
+import { checkAnswer, CheckResult, AnswerType } from "./checkAnswer";
 
 // Тип одной задачи (можешь расширить, если у тебя есть дополнительные поля)
 export type VariantTask = {
   id: number | string;
-  answerType: string;
+  answerType: AnswerType;
   correctAnswer: any;
   userAnswer: any;
   maxScore?: number;
@@ -38,7 +38,7 @@ export function checkVariant(
       answerType: task.answerType,
       correctAnswer: task.correctAnswer,
       userAnswer,
-      maxScore: task.maxScore,
+      maxScore: task.maxScore ?? 1,
     });
     results.push(result);
     totalPrimary += result.score;


### PR DESCRIPTION
## Summary
- align `[task]` page params with generated types
- make `VariantTask.answerType` use strict `AnswerType`
- ensure `checkVariant` passes a default score

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881571d070c832d9ef3abf60927d2b1